### PR TITLE
Make value headings one level down.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ At Lullabot, we’re a team with a wide variety of backgrounds coming together t
 
 These Engineering Values exist to guide our team in the work we produce and the interactions we have with each other. These values overlap and expand on our [Core Values](https://www.lullabot.com/values) - they’re not a hierarchy or a tree. When solutions aren’t obvious, or there’s conflict, we use these values to ground our decisions.
 
-# People matter more
+## People matter more
 
 We build systems and processes for people first—and if we forget or ignore those people, our systems become a source of dread, rather than a source of delight. A project that launches on time and on budget, but burns out a team, isn’t successful. Helping others when opportunities appear keeps us connected, even when we’re separated by great distances.
 
@@ -12,31 +12,31 @@ In our work, we use many tools as a means of communication, such as instant mess
 
 The work we produce is not separate from the world in which we live. We value human safety and security. While we do not always have direct control over how our work is used, we aim to create products that do not actively harm any one group. We draw on our empathy to build tools and products that equitably empower everyone who uses them, considering the impact of unintended consequences.
 
-# Cultivate inclusivity
+## Cultivate inclusivity
 
 We value diversity and inclusion. Beyond its intrinsic value, inclusion has an impact on a technical level. Our overarching goal is to identify or to be the experts and advocates for people who are not directly represented by our project teams. For example, we seek out the voice of the end-user, because client perspectives can sometimes miss key factors that only a user would know. We work towards equitable teams so that our work reflects the diverse world we live in. And, we continuously evaluate and respond to feedback, because the voices that are missing are going to be different from project to project.
 
 We cultivate inclusivity at a technical level by building accessible products because the software we build should function for everyone. Sometimes that means educating our clients about the importance of accessibility. Further, we aspire to work using tools that are accessible themselves and seek to use accessible language and technologies in our documentation so that differently-abled people can work on both sides of the keyboard.
 
-# Learn and share
+## Learn and share
 
 We find our work fulfilling because we are always given the opportunity to learn something new. We like to work on new, unsolved problems over applying the same solutions to the same problems. Learning and sharing, with ourselves, our clients, and open communities is woven through all the work we do day by day.
 
 We believe that the best engineering comes from sharing and building together as a group. We embrace open-source software and processes. Public critiques keep us innovating, and save us from reinventing the wheel. By integrating collaboration into our daily work, we create the space for our team to ask for help and to be generous with their knowledge.
 
-# Excellence balances perfect and done
+## Excellence balances perfect and done
 
 We find the balance between getting things done and architectural zen. When we solve tricky software engineering problems, we also consider when we are seeing diminishing returns. Rather than creating in isolation, we iterate using real-world feedback and quantitative results to evaluate our work.
 
 Some projects need tactical engineering measures that are not meant to last. Other times, we discover new information, and we need to stop working to discuss the options again. Not all project scenarios are ideal, but we work with our clients to find out what works best for their project.
 
-# Code for the future
+## Code for the future
 
 We think about the big picture before making important decisions. Creating a system to solve a complex problem is only the first part of a software project. Good systems last because they are maintainable and also maximize value for the client. Others will inherit our work and need to improve and maintain it. We don’t have perfect memory and know that sometimes the inheritors are just “future us.” We optimize code for future readers, even if that means using more verbose language or limiting the use of uncommon language features.
 
 We delight in automating away repetition for ourselves, the community, and our clients. Automation promises to reduce technical debt in our code, make our processes more robust, and save time and money. However, automation can also add unnecessary complexity and waste time. Just because we *can* automate something doesn’t mean we *should*.
 
-# Work joy into work
+## Work joy into work
 
 As engineers, we have a tendency to look at technical challenges as fun puzzles to be solved. We try things, we break things, and we try again. We come back to work each day because we enjoy tinkering with the systems we build. When planning our work, we strive to leave room for joy, even with tight deadlines and exacting requirements.
 


### PR DESCRIPTION
It seems good to have some differentiation between the document main title and the values themselves, so I'm just adding one heading level to each of them.